### PR TITLE
fix: update delete button type and handle redirect correctly

### DIFF
--- a/src/pages/Edition/NewEdition/index.tsx
+++ b/src/pages/Edition/NewEdition/index.tsx
@@ -265,8 +265,8 @@ export default function NewEdition({ edition: _ed }: { edition?: Edition }) {
                 fallback={true}
               >
                 <button
-                  type="submit"
-                  value={"delete"}
+                  type="button"
+                  onClick={handleDelete}
                   className="p-2 text-white bg-red-500 rounded hover:bg-indigo-500"
                 >
                   Delete Edition


### PR DESCRIPTION
What was wrong: The frontend code is written to only redirect (navigate back) if it receives a "Success" (200 OK) signal.

Why it stuck: Because the backend crashed during logging, it sent back an "Error" (500) signal. The frontend received this error, so it skipped the Maps() function and stayed on the page, even though the item was actually gone from the database.

The Fix: I also cleaned up the button. I changed it from a submit button (which tries to send the whole form) to a standard button with a dedicated onClick handler. This prevents it from interfering with the main form logic.