### PR TITLE
fixed edition image deletion function not sending the email to the ba…

### DIFF
--- a/src/pages/Edition/NewEdition/index.tsx
+++ b/src/pages/Edition/NewEdition/index.tsx
@@ -1,5 +1,6 @@
 import { PermissionProtector } from "@/components/PermissionProtector";
 import { Spinner } from "@/components/Spinner";
+import { CurrUserCtx } from "@/contexts/current_user";
 import { ErrorContext } from "@/contexts/error";
 import API from "@/services/API";
 import { IEdition as Edition } from "@/commonlib/types/edition";
@@ -22,13 +23,16 @@ export default function NewEdition({ edition: _ed }: { edition?: Edition }) {
   const location = useLocation();
   const navigate = useNavigate();
   const { setError } = useContext(ErrorContext);
+  const { user } = useContext(CurrUserCtx);
   const { id } = useParams<{ id: string }>();
   const [edition, setEdition] = useState<Edition>(null);
   const toastId = useRef(null);
 
   const handleDelete = () => {
     if (window.confirm("Are you sure you want to word this edition?")) {
-      API.delete(`/edition/delete-edition/${id}`)
+      API.delete(`/edition/delete-edition/${id}`, {
+        data: { email: user?.email },
+      })
         .then(() => {
           toast.success("Edition deleted successfully!");
           navigate("/edition/all-editions");

--- a/src/pages/Edition/NewEdition/index.tsx
+++ b/src/pages/Edition/NewEdition/index.tsx
@@ -29,7 +29,7 @@ export default function NewEdition({ edition: _ed }: { edition?: Edition }) {
   const toastId = useRef(null);
 
   const handleDelete = () => {
-    if (window.confirm("Are you sure you want to word this edition?")) {
+    if (window.confirm("Are you sure you want to delete this edition?")) {
       API.delete(`/edition/delete-edition/${id}`, {
         data: { email: user?.email },
       })


### PR DESCRIPTION

## Description



This PR ensures that when an edition is deleted, its associated cover image and thumbnail are also deleted from the filesystem storage (`uploads/` and `thumbnails/`).



### Changes



#### Backend (`nix-backend-v2`)

- **Imports**: Added `fs` module to editionController.ts

- **File Deletion**: Inside the `deleteEdition` controller, added asynchronous filesystem cleanup using `fs.unlink`:

  - Deletes original cover image at `uploads/edition-${edition.edition_id}`

  - Deletes generated cover thumbnail at `thumbnails/edition-${edition.edition_id}_256`

- **Error Handling**: Ignored `ENOENT` (file not found) errors to prevent backend failures or false logs if an edition doesn't have an associated image.



#### Frontend (`nix-frontend-v2`)

- **API Call**: Updated the `handleDelete` method in NewEdition/index.tsx to pass the deleting user's email payload (`user?.email`) to the delete request, which matches backend expectations for auditing/logging.


https://github.com/user-attachments/assets/526f9ab0-486e-4510-aecb-e29417dc8bdf






